### PR TITLE
Fix WebGL crash in Wallpaper Engine 1.3

### DIFF
--- a/script.js
+++ b/script.js
@@ -179,7 +179,7 @@ function pointerPrototype () {
     this.dy = 0;
     this.down = false;
     this.moved = false;
-    this.color = [30, 0, 300];
+    this.color = config.COLORFUL ? generateColor() : config.POINTER_COLOR.getRandom();
 }
 
 let pointers = [];


### PR DESCRIPTION
The color object may not be initialized as an array, it needs to be an object as in the other places of the code.