### PR TITLE
Enable Wallpaper Engine FPS limiter support.

### DIFF
--- a/project.json
+++ b/project.json
@@ -151,14 +151,6 @@
 				"type" : "bool",
 				"value" : true
 			},
-			"fps" : 
-			{
-				"index" : 33,
-				"order" : 133,
-				"text" : "Max FPS",
-				"type" : "textinput",
-				"value" : "60"
-			},
 			"frequency_range" : 
 			{
 				"condition" : "audio_responsive.value",

--- a/project.json
+++ b/project.json
@@ -9,6 +9,7 @@
 		{
 			"audio_responsive" : 
 			{
+				"index" : 17,
 				"order" : 117,
 				"text" : "Audio Responsive",
 				"type" : "bool",
@@ -16,6 +17,7 @@
 			},
 			"background_color" : 
 			{
+				"index" : 6,
 				"order" : 106,
 				"text" : "Background Color",
 				"type" : "color",
@@ -25,6 +27,7 @@
 			{
 				"condition" : "use_background_image.value",
 				"fileType" : "image",
+				"index" : 3,
 				"order" : 103,
 				"text" : "Background Image",
 				"type" : "file",
@@ -33,6 +36,7 @@
 			"background_image_size" : 
 			{
 				"condition" : "use_background_image.value",
+				"index" : 5,
 				"options" : 
 				[
 					{
@@ -52,18 +56,20 @@
 			"bloom_intensity" : 
 			{
 				"fraction" : true,
+				"index" : 31,
 				"max" : 2,
-				"min" : 0.10000000000000001,
+				"min" : 0.1,
 				"order" : 131,
 				"precision" : 2,
 				"step" : 0.01,
 				"text" : "Bloom Intensity",
 				"type" : "slider",
-				"value" : 0.80000000000000004
+				"value" : 0.8
 			},
 			"bloom_threshold" : 
 			{
 				"fraction" : true,
+				"index" : 32,
 				"max" : 1,
 				"min" : 0,
 				"order" : 132,
@@ -71,10 +77,11 @@
 				"step" : 0.01,
 				"text" : "Bloom Threshold",
 				"type" : "slider",
-				"value" : 0.59999999999999998
+				"value" : 0.6
 			},
 			"colorful" : 
 			{
+				"index" : 10,
 				"order" : 110,
 				"text" : "Random Color",
 				"type" : "bool",
@@ -83,17 +90,19 @@
 			"density_diffusion" : 
 			{
 				"fraction" : true,
+				"index" : 23,
 				"max" : 1,
-				"min" : 0.90000000000000002,
+				"min" : 0.9,
 				"order" : 123,
 				"precision" : 3,
 				"step" : 0.001,
 				"text" : "Density Diffusion",
 				"type" : "slider",
-				"value" : 0.96999999999999997
+				"value" : 0.97
 			},
 			"dye_resolution" : 
 			{
+				"index" : 22,
 				"options" : 
 				[
 					{
@@ -136,15 +145,25 @@
 			},
 			"enable_bloom" : 
 			{
+				"index" : 30,
 				"order" : 130,
 				"text" : "Enable Bloom",
 				"type" : "bool",
 				"value" : true
 			},
+			"fps" : 
+			{
+				"index" : 33,
+				"order" : 133,
+				"text" : "Max FPS",
+				"type" : "textinput",
+				"value" : "60"
+			},
 			"frequency_range" : 
 			{
 				"condition" : "audio_responsive.value",
 				"fraction" : false,
+				"index" : 19,
 				"max" : 62,
 				"min" : 1,
 				"order" : 119,
@@ -156,6 +175,7 @@
 			{
 				"condition" : "audio_responsive.value",
 				"fraction" : false,
+				"index" : 20,
 				"max" : 62,
 				"min" : 0,
 				"order" : 120,
@@ -165,6 +185,7 @@
 			},
 			"idle_random_splats" : 
 			{
+				"index" : 7,
 				"order" : 107,
 				"text" : "Idle Random Splats",
 				"type" : "bool",
@@ -173,6 +194,7 @@
 			"more_colors" : 
 			{
 				"condition" : "!colorful.value",
+				"index" : 12,
 				"order" : 112,
 				"text" : "More Colors",
 				"type" : "bool",
@@ -180,6 +202,7 @@
 			},
 			"paused" : 
 			{
+				"index" : 29,
 				"order" : 129,
 				"text" : "Paused",
 				"type" : "bool",
@@ -188,6 +211,7 @@
 			"pressure_diffusion" : 
 			{
 				"fraction" : true,
+				"index" : 25,
 				"max" : 1,
 				"min" : 0,
 				"order" : 125,
@@ -195,12 +219,13 @@
 				"step" : 0.01,
 				"text" : "Pressure Diffusion",
 				"type" : "slider",
-				"value" : 0.80000000000000004
+				"value" : 0.8
 			},
 			"random_splat_amount" : 
 			{
 				"condition" : "idle_random_splats.value",
 				"fraction" : true,
+				"index" : 9,
 				"max" : 100,
 				"min" : 1,
 				"order" : 109,
@@ -214,6 +239,7 @@
 			{
 				"condition" : "idle_random_splats.value",
 				"fraction" : true,
+				"index" : 8,
 				"max" : 5,
 				"min" : 0,
 				"order" : 108,
@@ -226,6 +252,7 @@
 			"repeat_background" : 
 			{
 				"condition" : "use_background_image.value",
+				"index" : 4,
 				"order" : 104,
 				"text" : "Repeat Background",
 				"type" : "bool",
@@ -240,6 +267,7 @@
 			},
 			"shading" : 
 			{
+				"index" : 28,
 				"order" : 128,
 				"text" : "Shading",
 				"type" : "bool",
@@ -247,6 +275,7 @@
 			},
 			"show_mouse_movement" : 
 			{
+				"index" : 0,
 				"order" : 100,
 				"text" : "Show Mouse Movement",
 				"type" : "bool",
@@ -254,6 +283,7 @@
 			},
 			"simulation_resolution" : 
 			{
+				"index" : 21,
 				"options" : 
 				[
 					{
@@ -282,6 +312,7 @@
 			{
 				"condition" : "audio_responsive.value",
 				"fraction" : true,
+				"index" : 18,
 				"max" : 10,
 				"min" : 0,
 				"order" : 118,
@@ -294,6 +325,7 @@
 			"splat_color" : 
 			{
 				"condition" : "!colorful.value",
+				"index" : 11,
 				"order" : 111,
 				"text" : "Splat Color",
 				"type" : "color",
@@ -302,6 +334,7 @@
 			"splat_color_2" : 
 			{
 				"condition" : "more_colors.value && !colorful.value",
+				"index" : 13,
 				"order" : 113,
 				"text" : "Splat Color 2",
 				"type" : "color",
@@ -310,6 +343,7 @@
 			"splat_color_3" : 
 			{
 				"condition" : "more_colors.value && !colorful.value",
+				"index" : 14,
 				"order" : 114,
 				"text" : "Splat Color 3",
 				"type" : "color",
@@ -318,6 +352,7 @@
 			"splat_color_4" : 
 			{
 				"condition" : "more_colors.value && !colorful.value",
+				"index" : 15,
 				"order" : 115,
 				"text" : "Splat Color 4",
 				"type" : "color",
@@ -326,6 +361,7 @@
 			"splat_color_5" : 
 			{
 				"condition" : "more_colors.value && !colorful.value",
+				"index" : 16,
 				"order" : 116,
 				"text" : "Splat Color 5",
 				"type" : "color",
@@ -333,6 +369,7 @@
 			},
 			"splat_on_click" : 
 			{
+				"index" : 1,
 				"order" : 101,
 				"text" : "Splat on click",
 				"type" : "bool",
@@ -341,6 +378,7 @@
 			"splat_radius" : 
 			{
 				"fraction" : true,
+				"index" : 27,
 				"max" : 1,
 				"min" : 0.01,
 				"order" : 127,
@@ -348,10 +386,11 @@
 				"step" : 0.01,
 				"text" : "Splat Radius",
 				"type" : "slider",
-				"value" : 0.29999999999999999
+				"value" : 0.3
 			},
 			"use_background_image" : 
 			{
+				"index" : 2,
 				"order" : 102,
 				"text" : "Use Background Image",
 				"type" : "bool",
@@ -360,18 +399,20 @@
 			"velocity_diffusion" : 
 			{
 				"fraction" : true,
+				"index" : 24,
 				"max" : 1,
-				"min" : 0.90000000000000002,
+				"min" : 0.9,
 				"order" : 124,
 				"precision" : 3,
 				"step" : 0.001,
 				"text" : "Velocity Diffusion",
 				"type" : "slider",
-				"value" : 0.97999999999999998
+				"value" : 0.98
 			},
 			"vorticity" : 
 			{
 				"fraction" : false,
+				"index" : 26,
 				"max" : 50,
 				"min" : 0,
 				"order" : 126,
@@ -383,6 +424,8 @@
 		"supportsaudioprocessing" : true
 	},
 	"preview" : "preview.gif",
+	"ratingsex" : "none",
+	"ratingviolence" : "none",
 	"tags" : [ "Abstract" ],
 	"title" : "Colorful Fluid Animation [Audio Responsive]",
 	"type" : "web",

--- a/script.js
+++ b/script.js
@@ -45,7 +45,9 @@ let config = {
     RANDOM_AMOUNT: 10,
     RANDOM_INTERVAL: 1,
     SPLAT_ON_CLICK: true,
-    SHOW_MOUSE_MOVEMENT: true
+    SHOW_MOUSE_MOVEMENT: true,
+    FRAME_INTERVAL_MS: 1000 / 60,
+    STEP_SIZE_S: 0.016
 };
 
 document.addEventListener("DOMContentLoaded", () => {   
@@ -137,7 +139,10 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             if (properties.splat_on_click) config.SPLAT_ON_CLICK = properties.splat_on_click.value;
             if (properties.show_mouse_movement) config.SHOW_MOUSE_MOVEMENT = properties.show_mouse_movement.value;
-        }
+        },
+        applyGeneralProperties: (properties) => {
+            if (properties.fps) config.FRAME_INTERVAL_MS = 1000 / properties.fps;
+	}
     };
 
     window.wallpaperRegisterAudioListener((audioArray) => {
@@ -968,13 +973,22 @@ let lastColorChangeTime = Date.now();
 
 update();
 
-function update () {
+function update() {
+    setTimeout(update, config.FRAME_INTERVAL_MS);
+
     resizeCanvas();
     input();
-    if (!config.PAUSED)
-        step(0.016);
+
+    if (!config.PAUSED) {
+        var remainingTimeS = config.FRAME_INTERVAL_MS / 1000.0;
+        while (remainingTimeS > config.STEP_SIZE_S) {
+            step(config.STEP_SIZE_S);
+            remainingTimeS -= config.STEP_SIZE_S;
+        }
+        step(remainingTimeS);
+    }
+
     render(null);
-    requestAnimationFrame(update);
 }
 
 function input () {

--- a/script.js
+++ b/script.js
@@ -142,7 +142,7 @@ document.addEventListener("DOMContentLoaded", () => {
         },
         applyGeneralProperties: (properties) => {
             if (properties.fps) config.FRAME_INTERVAL_MS = 1000 / properties.fps;
-	}
+	    }
     };
 
     window.wallpaperRegisterAudioListener((audioArray) => {


### PR DESCRIPTION
Limiting FPS saves some power especially on high refresh rate monitors.
For FPS below 60hz the simulation step is done multiple times to keep things stable.